### PR TITLE
Save timestamps for each region to JSON file

### DIFF
--- a/src/AriesCounters.c
+++ b/src/AriesCounters.c
@@ -35,8 +35,6 @@ int write_header = 0;
 char *caller_program;
 
 /* utilities for timing each region/timestep */
-unsigned long long tempo1, tempo2;
-
 struct timeval startTime;
 
 struct timeval get_timestamp() {
@@ -58,20 +56,8 @@ char *get_formatted_timestamp(struct timeval tv) {
     return tmbuf;
 }
 
-unsigned long long get_time_ns() {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
+unsigned long long get_time_ns(struct timeval tv) {
     return tv.tv_sec * 1000000000ll + tv.tv_usec * 1000ll;
-}
-
-void StartSysTimer() {
-    tempo1 = get_time_ns();
-}
-
-/* Returns time elapsed since last call to StartSysTimer, in nanoseconds. */
-unsigned long long EndSysTimer() {
-    tempo2 = get_time_ns();
-    return tempo2 - tempo1;
 }
 
 /* The list of counters which will be printed at the end */
@@ -201,7 +187,6 @@ void StartRecordAriesCounters(int my_rank, int reporting_rank_mod, int* AC_event
     PAPI_start(*AC_event_set);
 
     // Start a timer to measure elapsed time
-    StartSysTimer();	
     startTime = get_timestamp();
 
 }
@@ -214,7 +199,6 @@ void EndRecordAriesCounters(int my_rank, int reporting_rank_mod, int* AC_event_s
     if (my_rank % reporting_rank_mod != 0) { return; }
 
     // Stop timer for elapsed time
-    unsigned long long elapsed_time = EndSysTimer();
     struct timeval endTime = get_timestamp();
 
     PAPI_stop(*AC_event_set, *AC_values);
@@ -230,8 +214,7 @@ void EndRecordAriesCounters(int my_rank, int reporting_rank_mod, int* AC_event_s
     // Store the region number.
     new_counters->timestep = region;
 
-    // Store the elapsed time for this rank.
-    new_counters->elapsed_time = elapsed_time;
+    // Store the timers for this rank.
     new_counters->start_time = startTime;
     new_counters->end_time = endTime;
 
@@ -254,7 +237,6 @@ void FinalizeAriesCounters(MPI_Comm* mod16_comm, int my_rank, int reporting_rank
 
     // Allocate space to gather counters and timing.
     long long *counter_data = (long long*)malloc(sizeof(long long) * number_of_reporting_ranks * *AC_event_count);
-    unsigned long long *timer_data = (unsigned long long *)malloc(sizeof(unsigned long long) * number_of_reporting_ranks);
     struct timeval *start_times = (struct timeval *)malloc(sizeof(struct timeval) * number_of_reporting_ranks);
     struct timeval *end_times = (struct timeval *)malloc(sizeof(struct timeval) * number_of_reporting_ranks);
 
@@ -272,10 +254,6 @@ void FinalizeAriesCounters(MPI_Comm* mod16_comm, int my_rank, int reporting_rank
 	MPI_Gather(ref->counters, *AC_event_count, MPI_LONG_LONG,
 		counter_data, *AC_event_count, MPI_LONG_LONG, 0, *mod16_comm);
 
-	/* MPI_Gather to collect timing from all ranks to 0 */
-	MPI_Gather(&(ref->elapsed_time), 1, MPI_LONG_LONG,
-		timer_data, 1, MPI_LONG_LONG_INT, 0, *mod16_comm);
-
 	/* MPI_Gather to collect start and end timestamps from all ranks to 0 */
 	MPI_Gather(&(ref->start_time), sizeof(struct timeval), MPI_BYTE,
 		start_times, sizeof(struct timeval), MPI_BYTE, 0, *mod16_comm);
@@ -288,7 +266,7 @@ void FinalizeAriesCounters(MPI_Comm* mod16_comm, int my_rank, int reporting_rank
 	    int timestep = ref->timestep;
 	    sprintf(bin_filename, "%s.counters.%d.bin", caller_program, timestep);
 
-	    WriteAriesCounters(number_of_reporting_ranks, reporting_rank_mod, counter_data, timer_data, start_times, end_times, timestep, json_filename, bin_filename, AC_events, AC_event_count);
+	    WriteAriesCounters(number_of_reporting_ranks, reporting_rank_mod, counter_data, start_times, end_times, timestep, json_filename, bin_filename, AC_events, AC_event_count);
 	}
 	// Have everyone wait until rank 0 finishes, since it may take a while.
 	MPI_Barrier(*mod16_comm);
@@ -331,7 +309,7 @@ void FinalizeAriesCounters(MPI_Comm* mod16_comm, int my_rank, int reporting_rank
     PAPI_shutdown();
 }
 
-void WriteAriesCounters(int number_of_reporting_ranks, int reporting_rank_mod, long long *counter_data, unsigned long long *timer_data, struct timeval *start_times, struct timeval *end_times, int timestep, char* jsonfile, char* binfile, char*** AC_events, int* AC_event_count) {
+void WriteAriesCounters(int number_of_reporting_ranks, int reporting_rank_mod, long long *counter_data, struct timeval *start_times, struct timeval *end_times, int timestep, char* jsonfile, char* binfile, char*** AC_events, int* AC_event_count) {
     int i, j;
     FILE *fp;
 
@@ -361,8 +339,9 @@ void WriteAriesCounters(int number_of_reporting_ranks, int reporting_rank_mod, l
     fprintf(fp, "            \"timestep\": %d,\n", timestep);
     fprintf(fp, "            \"time\": [");
     for (i = 0; i < number_of_reporting_ranks-1; i++)
-	fprintf(fp, "%ld, ", timer_data[i]);
-    fprintf(fp, "%ld", timer_data[number_of_reporting_ranks-1]);
+	fprintf(fp, "%ld, ", get_time_ns(end_times[i]) - get_time_ns(start_times[i]));
+    fprintf(fp, "%ld", get_time_ns(end_times[number_of_reporting_ranks-1])
+                       - get_time_ns(start_times[number_of_reporting_ranks-1]));
     fprintf(fp, "],\n");
     fprintf(fp, "            \"start\": [");
     for (i = 0; i < number_of_reporting_ranks-1; i++)

--- a/src/AriesCounters.h
+++ b/src/AriesCounters.h
@@ -17,6 +17,8 @@
 #ifndef ARIESCOUNTERS_H
 #define ARIESCOUNTERS_H
 
+#include <sys/time.h> // gettimeofday
+
 #define MAX_COUNTER_NAME_LENGTH 70
 
 /* Functions for timing that use gettimeofday */
@@ -30,6 +32,8 @@ struct timestep_counters {
     long long *counters;
     int timestep;
     unsigned long long elapsed_time; 
+    struct timeval start_time;
+    struct timeval end_time;
     struct timestep_counters *next;
 };
 
@@ -47,6 +51,6 @@ void EndRecordAriesCounters(int my_rank, int reporting_rank_mod, int* AC_event_s
 
 void FinalizeAriesCounters(MPI_Comm* mod16_comm, int my_rank, int reporting_rank_mod, int* AC_event_set, char*** AC_events, long long** AC_values, int* AC_event_count);
 
-void WriteAriesCounters(int number_of_reporting_ranks, int reporting_rank_mod, long long *counter_data, unsigned long long *timer_data, int timestep, char* jsonfile, char* binfile, char*** AC_events, int* AC_event_count);
+void WriteAriesCounters(int number_of_reporting_ranks, int reporting_rank_mod, long long *counter_data, unsigned long long *timer_data, struct timeval *start_times, struct timeval *end_times, int timestep, char* jsonfile, char* binfile, char*** AC_events, int* AC_event_count);
 
 #endif

--- a/src/AriesCounters.h
+++ b/src/AriesCounters.h
@@ -21,17 +21,12 @@
 
 #define MAX_COUNTER_NAME_LENGTH 70
 
-/* Functions for timing that use gettimeofday */
-void StartSysTimer();
-unsigned long long EndSysTimer();
-
 /* Store counters in memory in a linked list, reporting them to rank 0 at the
  * end.
  */
 struct timestep_counters {
     long long *counters;
     int timestep;
-    unsigned long long elapsed_time; 
     struct timeval start_time;
     struct timeval end_time;
     struct timestep_counters *next;
@@ -51,6 +46,6 @@ void EndRecordAriesCounters(int my_rank, int reporting_rank_mod, int* AC_event_s
 
 void FinalizeAriesCounters(MPI_Comm* mod16_comm, int my_rank, int reporting_rank_mod, int* AC_event_set, char*** AC_events, long long** AC_values, int* AC_event_count);
 
-void WriteAriesCounters(int number_of_reporting_ranks, int reporting_rank_mod, long long *counter_data, unsigned long long *timer_data, struct timeval *start_times, struct timeval *end_times, int timestep, char* jsonfile, char* binfile, char*** AC_events, int* AC_event_count);
+void WriteAriesCounters(int number_of_reporting_ranks, int reporting_rank_mod, long long *counter_data, struct timeval *start_times, struct timeval *end_times, int timestep, char* jsonfile, char* binfile, char*** AC_events, int* AC_event_count);
 
 #endif


### PR DESCRIPTION
Added start and end timestamps for each region to the "timings" section of the JSON file. Timestamps are printed in %Y-%m-%d %H:%M:%S %Z format.